### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const path = require('path');
 const glob = require('glob');
 const prettier = require('prettier');
 


### PR DESCRIPTION
Generally, to fix this kind of issue, you either remove the unused variable/import or start using it meaningfully if it was intended to be used. Since there is no evidence that `path` is required, the appropriate fix is to delete the unused `require('path')` statement.

Concretely, in `scripts/generate-sitemap.js`, remove the line `const path = require('path');` (line 2 in the snippet). No other code changes are required, because no references to `path` exist in the shown code, so functionality will remain unchanged. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._