### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/plugins/seo-plugin.js
+++ b/src/plugins/seo-plugin.js
@@ -8,7 +8,7 @@
 
 function seoPlugin(context, options) {
   const {
-    siteConfig: { url, baseUrl },
+    siteConfig: { baseUrl },
   } = context;
 
   return {


### PR DESCRIPTION
To fix the problem, remove the unused `url` variable from the destructuring of `context.siteConfig` so that only `baseUrl` is extracted. This keeps the plugin behavior identical while eliminating the unused binding.

Concretely, in `src/plugins/seo-plugin.js`, update the destructuring assignment on lines 10–12 to omit `url`. No additional imports or method changes are necessary. The rest of the plugin can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._